### PR TITLE
Allow removing original embed instead of own

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Disclaimer: This public instance is hosted on my Raspberry Pi and I make no guar
 The bot's permissions system is designed to be granular, minimal, and gracefully degrade in the absence of those unnecessary for basic function.
 
 - *Read Messages* and *Send Messages* are **required** to perform the cleaning.
-- *Manage Messages* is **recommended** so the bot can suppress embeds on its own links to reduce visual clutter.
+- *Manage Messages* is **recommended** so the bot can suppress embeds on the original message's links to reduce visual clutter.
 - *Read Message History* and *Add Reactions* are **optional** for the original poster to easily delete the bot's replies with the `:wastebasket:` emoji. Note that these two permissions are on by default for `@everyone`. If you want to disable react-to-remove, turn off these permissions for `@everyone` and give every human in your server a new role. This functionality also **requires** *Manage Messages* for deletion.
 
 ## Self-Hosting

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Disclaimer: This public instance is hosted on my Raspberry Pi and I make no guar
 The bot's permissions system is designed to be granular, minimal, and gracefully degrade in the absence of those unnecessary for basic function.
 
 - *Read Messages* and *Send Messages* are **required** to perform the cleaning.
-- *Manage Messages* is **recommended** so the bot can suppress embeds on the original message's links to reduce visual clutter.
+- *Manage Messages* is **recommended** so the bot can suppress embeds on the original message's links to reduce visual clutter. Otherwise, it will suppress embeds on its own links.
 - *Read Message History* and *Add Reactions* are **optional** for the original poster to easily delete the bot's replies with the `:wastebasket:` emoji. Note that these two permissions are on by default for `@everyone`. If you want to disable react-to-remove, turn off these permissions for `@everyone` and give every human in your server a new role. This functionality also **requires** *Manage Messages* for deletion.
 
 ## Self-Hosting

--- a/main.py
+++ b/main.py
@@ -33,14 +33,14 @@ async def on_ready():
 @client.event
 async def on_message(message):
     messages.inc()
+    permissions = message.channel.permissions_for(message.guild.me)
     if message.author == client.user:
-        permissions = message.channel.permissions_for(message.guild.me)
-        # Suppress embeds for bot messages to avoid visual clutter
-        if permissions.manage_messages:
+        # Suppress embeds for bot messages if unable to suppress embeds for original message to avoid visual clutter
+        if not permissions.manage_messages:
             await message.edit(suppress=True)
-            # Add :wastebasket: emoji for easy deletion if necessary
-            if permissions.add_reactions and permissions.read_message_history:
-                await message.add_reaction('🗑')
+        # Add :wastebasket: emoji for easy deletion if necessary
+        if permissions.add_reactions and permissions.read_message_history:
+            await message.add_reaction('🗑')
     # Though this else is not necessary since the bot should never send
     # links with tracking parameters, include it anyways to be safe
     # against infinite recursion
@@ -54,6 +54,9 @@ async def on_message(message):
 
         # Send message and add reactions
         if cleaned:
+            # Suppress embeds for original message to avoid visual clutter
+            if permissions.manage_messages:
+                await message.edit(suppress=True)
             text = 'It appears that you have sent one or more links with tracking parameters. Below are the same links with those fields removed:\n' + '\n'.join(cleaned)
             await message.reply(text, mention_author=False)
             cleaned_messages.inc()

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ async def on_message(message):
         if not permissions.manage_messages:
             await message.edit(suppress=True)
         # Add :wastebasket: emoji for easy deletion if necessary
-        if permissions.add_reactions and permissions.read_message_history:
+        if permissions.add_reactions and permissions.read_message_history and permissions.manage_messages:
             await message.add_reaction('🗑')
     # Though this else is not necessary since the bot should never send
     # links with tracking parameters, include it anyways to be safe


### PR DESCRIPTION
From my testing, the Manage Messages permission is *only* required to remove the embeds from someone *else's* message.

This PR changes it so that if the bot does not have Manage Messages permission, it will remove its own embed, to reduce visual clutter. If it *does* have Manage Messages permission, it will remove the embed on the *original* comment, so that the link that takes up the most visual space is the one *without tracking*.