### PR TITLE
Ignore trailing &, /, ? in the comparison

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,8 @@ async def on_message(message):
         urls = re.findall('(?P<url>https?://[^\s]+)', message.content)
         cleaned = []
         for url in urls:
-            if clear_url(url) != url:
+            # Ignore trailing &, /, ? in comparing, as these are not used for tracking
+            if clear_url(url).strip('&/?') != url.strip('&/?'):
                 cleaned.append(clear_url(url))
 
         # Send message and add reactions


### PR DESCRIPTION
I noticed an issue where a user in one of my servers pasted an image URL and received an unwelcome reply from the bot. It seems to be a consistent issue that if a user uses "copy link" on an image from within Discord and pastes it elsewhere in Discord, that URL will have a trailing ampersand, which triggers the bot.

In my belief, a simple ampersand is not a tracking parameter, and the image is usually being viewed within Discord rather than clicked on and browsed to in a browser anyway. So it is inappropriate for the bot to respond. *Especially* in the current mode where the bot will remove its own embeds, creating a useless "📎image.png" link.

I also added slash and question mark to this PR because I have seen cases entirely unrelated to this bot where they have caused vaguely similar issues, but the ampersand is the only one I've seen specifically cause *this* issue.